### PR TITLE
Using MapLayer

### DIFF
--- a/IOManager.py
+++ b/IOManager.py
@@ -45,7 +45,7 @@ def export_png(parent: QtWidgets.QWidget):
     if parent.map.get_tile_layer():
         output_map = QFileDialog.getSaveFileName(parent, 'Save file', '.', filter='PNG file (*.png)')[0]
         if output_map:
-            map_to_png(parent.map, output_map)
+            map_to_png(parent.mapviewer, output_map)
 
 
 def new_map(parent: QtWidgets.QWidget):

--- a/layers/layer_type.py
+++ b/layers/layer_type.py
@@ -11,3 +11,6 @@ class LayerType(Enum):
 
     def __str__(self):
         return self.value
+
+
+LAYER_TYPE_WITH_OBJECTS = (LayerType.TRAFFIC_SIGNS, LayerType.GROUND_APRILTAG, LayerType.WATCHTOWERS, LayerType.ITEMS)

--- a/layers/map_layer.py
+++ b/layers/map_layer.py
@@ -1,4 +1,8 @@
-from layers.layer_type import LayerType
+from layers.layer_type import LayerType, LAYER_TYPE_WITH_OBJECTS
+
+import logging
+
+logger = logging.getLogger('root')
 
 
 class MapLayer:
@@ -46,3 +50,16 @@ class MapLayer:
             return layer_data
         else:
             return process_data(self.data)
+
+    def get_objects(self):
+        """
+        Get layer's objects
+        If layer_type doesn't support objects return empty generator TODO: add exceptions
+        :return: generator
+        """
+        if self.type not in LAYER_TYPE_WITH_OBJECTS:
+            logger.info("Layer type {} doesn't support objects. Allowed types: {}".format(self.type, LAYER_TYPE_WITH_OBJECTS))
+            yield from ()
+        else:
+            for layer_object in self.data:
+                yield layer_object

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -520,7 +520,7 @@ class duck_window(QtWidgets.QMainWindow):
 
     def keyPressEvent(self, e):
         selection = self.mapviewer.raw_selection
-        item_layer = self.map.get_item_layer().data
+        item_layer = self.map.get_objects_from_layers() # TODO: add self.current_layer for editing only it's objects?
         for item in item_layer:
             x, y = item.position['x'], item.position['y']
             if x > selection[0] and x < selection[2] and y > selection[1] and y < selection[3]:

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -236,7 +236,7 @@ class duck_window(QtWidgets.QMainWindow):
     # Действие по созданию новой карты
     def create_map_triggered(self):
         new_map(self)
-        logger.debug("Length - {}; Items - {}".format(len(self.map.get_tile_layer().data), len(self.map.get_item_layer().data)))
+        logger.debug("Length - {}".format(len(self.map.get_tile_layer().data)))
         self.mapviewer.offsetX = self.mapviewer.offsetY = 0
         self.mapviewer.scene().update()
         logger.debug("Creating a new map")

--- a/map.py
+++ b/map.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from layers.map_layer import MapLayer
-from layers.layer_type import LayerType
+from layers.layer_type import LayerType, LAYER_TYPE_WITH_OBJECTS
 
 import logging
 
@@ -56,6 +56,27 @@ class DuckietownMap:
             if layer.type == layer_type:
                 return layer
         return None
+
+    def get_object_layers(self, only_visible=False):
+        """
+        Get layers with layer_type, that supports object placement.
+        Layer types define by LAYER_TYPE_WITH_OBJECTS.
+        If only_visible is True, return only visible layers
+        :return: generator w/ layers
+        """
+        for layer in self.layers:
+            if layer.type in LAYER_TYPE_WITH_OBJECTS and layer.visible:
+                yield layer
+
+    def get_objects_from_layers(self, only_visible=False):
+        """
+        Get all objects from layers in map
+        If only_visible is True, return only objects from visible layers
+        :return: generator w/ objects
+        """
+        for layer in self.get_object_layers(only_visible):
+            for layer_object in layer.get_objects():
+                yield layer_object
 
     # Setters
 


### PR DESCRIPTION
- устранены использования `get_item_layer` (метод оставлен в тестах и методах `get_map_*/map_to_png`, поскольку они в дальнейшем будут изменены)
- использование `get_tile_layer`, поскольку слой остается и часто используется
- в `DuckietownMap` и `MapLayer` добавлены методы для получения размещенных объектов
- в `LAYER_TYPE_WITH_OBJECTS` определены типы слоев, на которых могут быть размещены объекты (слои знаков, тегов и башен) 
- модифицирован метод отрисовки `MapViewer.drawBackground`
   - не tile-слои обрабатываются одинаково, путем отрисовки их объектов
